### PR TITLE
fix: resolve Helm chart push pattern collision in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,13 +239,13 @@ jobs:
 
     - name: Push Helm charts to GHCR
       run: |
-        # Push parallax chart to GHCR
-        PARALLAX_CHART=$(ls packaged-charts/parallax-*.tgz)
+        # Push parallax chart to GHCR (exclude crds chart with negation)
+        PARALLAX_CHART=$(find packaged-charts -name 'parallax-*.tgz' ! -name '*crds*')
         echo "📦 Pushing parallax chart to GHCR: ${PARALLAX_CHART}"
         helm push "${PARALLAX_CHART}" oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
-        
-        # Push parallax-crds chart to GHCR  
-        CRDS_CHART=$(ls packaged-charts/parallax-crds-*.tgz)
+
+        # Push parallax-crds chart to GHCR
+        CRDS_CHART=$(find packaged-charts -name 'parallax-crds-*.tgz')
         echo "📦 Pushing parallax-crds chart to GHCR: ${CRDS_CHART}"
         helm push "${CRDS_CHART}" oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
         


### PR DESCRIPTION
## Problem

The v0.1.0 release failed during Helm chart publishing with this error:


## Root Cause

The pattern `ls packaged-charts/parallax-*.tgz` was matching **both** files:
- `parallax-0.1.0.tgz`  
- `parallax-crds-0.1.0.tgz`

This caused the `PARALLAX_CHART` variable to contain both filenames, making `helm push` fail.

## Solution

Fixed by using `find` with specific patterns:
- **parallax chart**: `find packaged-charts -name 'parallax-*.tgz' ! -name '*crds*'`
- **crds chart**: `find packaged-charts -name 'parallax-crds-*.tgz'`

This ensures each variable contains exactly one filename.

## Testing

- Pattern separation logic is clear and explicit
- No ambiguity between chart selection
- Maintains same functionality with correct file targeting

Fixes the failed release pipeline: https://github.com/matanryngler/parallax/actions/runs/17778697027