### PR TITLE
chore: bump chart versions to 0.1.1 for patch release

### DIFF
--- a/charts/parallax-crds/Chart.yaml
+++ b/charts/parallax-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: parallax-crds
 description: Parallax Custom Resource Definitions (CRDs)
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 home: https://github.com/matanryngler/parallax
 sources:

--- a/charts/parallax/Chart.yaml
+++ b/charts/parallax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: parallax
 description: A Helm chart for deploying the Parallax Operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 maintainers:
   - name: Matan Ryngler


### PR DESCRIPTION
## Summary

Bumps Helm chart versions from 0.1.0 to 0.1.1 to prepare for v0.1.1 patch release.

## Changes
- parallax chart: 0.1.0 → 0.1.1
- parallax-crds chart: 0.1.0 → 0.1.1
- Synced latest manifests to charts

## Release Process
After merging, create and push `v0.1.1` tag to trigger the release pipeline.